### PR TITLE
Feat: add GitHub Actions workflow for Copilot setup

### DIFF
--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -1,0 +1,21 @@
+on:
+  workflow_dispatch:
+permissions:
+  id-token: write
+  contents: read
+jobs:
+  copilot-setup-steps:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+    environment: copilot
+    steps:
+      - name: Install azd
+        uses: Azure/setup-azd@v2
+      - name: Azure login
+        uses: azure/login@a457da9ea143d694b1b9c7c869ebb04ebe844ef5
+        with:
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow for Copilot setup steps. The workflow is designed to be manually triggered and sets up Azure authentication for subsequent steps.

Key changes:

**Workflow Setup:**

* Added a new workflow file `.github/workflows/copilot-setup-steps.yml` that defines a job to run on `ubuntu-latest` and be triggered via `workflow_dispatch`.

**Azure Integration:**

* Configured the workflow to install the Azure Developer CLI (`azd`) using the `Azure/setup-azd@v2` action.
* Added a step for Azure login using the `azure/login` action, with credentials provided via GitHub secrets for client ID, tenant ID, and subscription ID.

**Permissions:**

* Set job-level and workflow-level permissions to allow writing `id-token` and reading `contents`, which are required for Azure authentication.